### PR TITLE
Added .gitignore to ignore sass-cache changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sass-cache

--- a/css/stanford_jumpstart_home.css
+++ b/css/stanford_jumpstart_home.css
@@ -17,11 +17,11 @@
 }
 
 /** LAYOUT: LOMITA ************************
-	- Full-bleed background image
-	- Big text block
-	- Video block
+    - Full-bleed background image
+    - Big text block
+    - Video block
 ******************************************/
-/* line 36, ../sass/stanford_jumpstart_home.scss */
+/* line 37, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita .content-top .block {
   border: none;
   padding: 1em;
@@ -35,273 +35,354 @@
   box-shadow: none;
 }
 
-/* line 44, ../sass/stanford_jumpstart_home.scss */
+/* line 46, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-bright .navbar {
   background: #53284f;
 }
-/* line 47, ../sass/stanford_jumpstart_home.scss */
+/* line 49, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-bright .content-top .block {
   background: #006374;
   color: white;
 }
-/* line 51, ../sass/stanford_jumpstart_home.scss */
+/* line 53, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-bright .site-footer {
   background: #53284f;
 }
 
-/* line 56, ../sass/stanford_jumpstart_home.scss */
+/* line 59, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-cardinal .navbar {
   background: #8c1515;
 }
-/* line 59, ../sass/stanford_jumpstart_home.scss */
+/* line 62, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-cardinal .content-top .block {
   background: #f2f1eb;
   color: white;
 }
-/* line 63, ../sass/stanford_jumpstart_home.scss */
+/* line 66, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-cardinal .site-footer {
   background: #8c1515;
 }
 
-/* line 68, ../sass/stanford_jumpstart_home.scss */
+/* line 72, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-contrast .navbar {
   background: #333333;
 }
-/* line 71, ../sass/stanford_jumpstart_home.scss */
+/* line 75, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-contrast .content-top .block {
   background: #333333;
   color: white;
 }
-/* line 75, ../sass/stanford_jumpstart_home.scss */
+/* line 79, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-contrast .site-footer {
   background: #333333;
 }
 
-/* line 80, ../sass/stanford_jumpstart_home.scss */
+/* line 85, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-dark .navbar {
   background: #282724;
 }
-/* line 83, ../sass/stanford_jumpstart_home.scss */
+/* line 88, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-dark .content-top .block {
   background: #232220;
   color: #2e2d29;
 }
-/* line 87, ../sass/stanford_jumpstart_home.scss */
+/* line 92, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-dark .site-footer {
   background: #282724;
 }
 
-/* line 92, ../sass/stanford_jumpstart_home.scss */
+/* line 98, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-light .navbar {
   background: #f8f7f2;
 }
-/* line 95, ../sass/stanford_jumpstart_home.scss */
+/* line 101, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-light .content-top .block {
   background: #e9e6df;
   color: #fbfbf9;
 }
-/* line 99, ../sass/stanford_jumpstart_home.scss */
+/* line 105, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-light .site-footer {
   background: #f8f7f2;
 }
 
-/* line 104, ../sass/stanford_jumpstart_home.scss */
+/* line 111, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-plain .navbar {
   background: white;
 }
-/* line 107, ../sass/stanford_jumpstart_home.scss */
+/* line 114, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-plain .content-top .block {
   background: #e9e9e9;
   color: white;
 }
-/* line 111, ../sass/stanford_jumpstart_home.scss */
+/* line 118, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-plain .site-footer {
   background: white;
 }
 
-/* line 116, ../sass/stanford_jumpstart_home.scss */
+/* line 124, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-rich .navbar {
   background: #d5d0c0;
 }
-/* line 119, ../sass/stanford_jumpstart_home.scss */
+/* line 127, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-rich .content-top .block {
   background: #d5d0c0;
   color: #fbfbf9;
 }
-/* line 123, ../sass/stanford_jumpstart_home.scss */
+/* line 131, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-lomita.style-custom-styles-rich .site-footer {
   background: #5e3032;
 }
 
 /** LAYOUT: MAYFIELD ************************
-	- Header background image
-	- Big text block
-	- Quote block
-	- Three blocks
+    - Header background image
+    - Big text block
+    - Quote block
+    - Three blocks
 ******************************************/
-/* line 137, ../sass/stanford_jumpstart_home.scss */
+/* line 145, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-mayfield #block-bean-jumpstart-lead-text-with-body {
   padding-right: 2em;
 }
-/* line 140, ../sass/stanford_jumpstart_home.scss */
+/* line 148, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-mayfield .bean-stanford-testimonial-block {
   margin-left: 2em;
 }
 @media (max-width: 767px) {
-  /* line 144, ../sass/stanford_jumpstart_home.scss */
+  /* line 152, ../sass/stanford_jumpstart_home.scss */
   .stanford-jumpstart-home-mayfield .bean-stanford-testimonial-block .postcard-right > div {
     display: block;
   }
-  /* line 147, ../sass/stanford_jumpstart_home.scss */
+  /* line 155, ../sass/stanford_jumpstart_home.scss */
   .stanford-jumpstart-home-mayfield .bean-stanford-testimonial-block .postcard-right > div:first-child {
     float: none;
   }
-  /* line 150, ../sass/stanford_jumpstart_home.scss */
+  /* line 158, ../sass/stanford_jumpstart_home.scss */
   .stanford-jumpstart-home-mayfield .bean-stanford-testimonial-block .postcard-right > div:first-child img {
     margin: 0;
   }
 }
 @media (max-width: 480px) {
-  /* line 155, ../sass/stanford_jumpstart_home.scss */
+  /* line 163, ../sass/stanford_jumpstart_home.scss */
   .stanford-jumpstart-home-mayfield #block-bean-jumpstart-lead-text-with-body {
     padding-right: 0;
   }
-  /* line 158, ../sass/stanford_jumpstart_home.scss */
+  /* line 166, ../sass/stanford_jumpstart_home.scss */
   .stanford-jumpstart-home-mayfield .bean-stanford-testimonial-block {
     margin-left: 0;
   }
 }
 
 /** LAYOUT: PALM ************************
-	- 12-column banner with overlay
-	- Three blocks
-	- Menu not full width
+    - 12-column banner with overlay
+    - Three blocks
+    - Menu not full width
 ******************************************/
-/* line 186, ../sass/stanford_jumpstart_home.scss */
+/* line 194, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm .site-main-menu {
   background: transparent;
   border: 0;
 }
-/* line 190, ../sass/stanford_jumpstart_home.scss */
+/* line 198, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm .navbar {
   padding: 0.5em;
   margin: 0;
 }
-/* line 193, ../sass/stanford_jumpstart_home.scss */
+/* line 201, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm .navbar .nav > li > a {
   padding: 0.25em 0.5em;
   border: 0;
   margin-right: 0.5em;
 }
-/* line 199, ../sass/stanford_jumpstart_home.scss */
+/* line 207, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm .header {
   background: transparent;
 }
 
-/* line 204, ../sass/stanford_jumpstart_home.scss */
+/* line 213, ../sass/stanford_jumpstart_home.scss */
 .front.stanford-jumpstart-home-palm .main {
   padding-top: 0;
 }
 
-/* line 209, ../sass/stanford_jumpstart_home.scss */
+/* line 219, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-bright .navbar {
   background: #53284f;
 }
-/* line 212, ../sass/stanford_jumpstart_home.scss */
+/* line 222, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-bright #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #53284f;
 }
-/* line 215, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a:hover, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a:focus, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-first-line a, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-first-line a:hover, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-first-line a:focus, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-second-line a, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-second-line a:hover, .stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-second-line a:focus {
+/* line 243, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-name a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-first-line a,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-first-line a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-first-line a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-second-line a,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-second-line a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-second-line a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line3 a,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line3 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line3 a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line4 a,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line4 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line4 a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line5 a,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line5 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-bright #site-title-line5 a:focus {
   color: #333333;
 }
-/* line 218, ../sass/stanford_jumpstart_home.scss */
+/* line 246, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-bright #header #logo {
   border-right: 1px solid #333333;
   background-image: url("../../../../themes/stanford_framework/logo.png");
   background-repeat: no-repeat;
   background-size: 180px auto;
+  background-position: left bottom;
 }
-/* line 224, ../sass/stanford_jumpstart_home.scss */
+/* line 253, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-bright #header #logo.site-logo {
+  border: none;
+}
+/* line 256, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-bright #header.line4 #logo {
+  background-position: left bottom 30px;
+}
+/* line 259, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-bright #header #logo a {
   display: inline-block;
 }
-/* line 227, ../sass/stanford_jumpstart_home.scss */
+/* line 262, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-bright #header #logo img {
   left: -1000px;
   position: relative;
   top: -1000px;
 }
 
-/* line 234, ../sass/stanford_jumpstart_home.scss */
+/* line 270, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-cardinal .navbar {
   background: #8c1515;
 }
-/* line 237, ../sass/stanford_jumpstart_home.scss */
+/* line 273, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-cardinal #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #8c1515;
 }
-/* line 240, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a:hover, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a:focus, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-first-line a, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-first-line a:hover, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-first-line a:focus, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-second-line a, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-second-line a:hover, .stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-second-line a:focus {
+/* line 294, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-name a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-first-line a,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-first-line a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-first-line a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-second-line a,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-second-line a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-second-line a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line3 a,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line3 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line3 a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line4 a,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line4 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line4 a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line5 a,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line5 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #site-title-line5 a:focus {
   color: #333333;
 }
-/* line 243, ../sass/stanford_jumpstart_home.scss */
+/* line 297, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-cardinal #header #logo {
   border-right: 1px solid #333333;
   background-image: url("../../../../themes/stanford_framework/logo.png");
   background-repeat: no-repeat;
   background-size: 180px auto;
+  background-position: left bottom;
 }
-/* line 249, ../sass/stanford_jumpstart_home.scss */
+/* line 304, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #header #logo.site-logo {
+  border: none;
+}
+/* line 307, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-cardinal #header.line4 #logo {
+  background-position: left bottom 30px;
+}
+/* line 310, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-cardinal #header #logo a {
   display: inline-block;
 }
-/* line 252, ../sass/stanford_jumpstart_home.scss */
+/* line 313, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-cardinal #header #logo img {
   left: -1000px;
   position: relative;
   top: -1000px;
 }
 
-/* line 259, ../sass/stanford_jumpstart_home.scss */
+/* line 321, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-contrast .navbar {
   background: #333333;
 }
-/* line 262, ../sass/stanford_jumpstart_home.scss */
+/* line 324, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-contrast #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #333333;
 }
-/* line 265, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a:hover, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a:focus, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-first-line a, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-first-line a:hover, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-first-line a:focus, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-second-line a, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-second-line a:hover, .stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-second-line a:focus {
+/* line 345, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-name a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-first-line a,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-first-line a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-first-line a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-second-line a,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-second-line a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-second-line a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line3 a,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line3 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line3 a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line4 a,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line4 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line4 a:focus,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line5 a,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line5 a:hover,
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #site-title-line5 a:focus {
   color: #333333;
 }
-/* line 268, ../sass/stanford_jumpstart_home.scss */
+/* line 348, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-contrast #header #logo {
   border-right: 1px solid #333333;
   background-image: url("../../../../themes/stanford_framework/logo.png");
   background-repeat: no-repeat;
   background-size: 180px auto;
+  background-position: left bottom;
 }
-/* line 274, ../sass/stanford_jumpstart_home.scss */
+/* line 355, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #header #logo.site-logo {
+  border: none;
+}
+/* line 358, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-palm.style-custom-styles-contrast #header.line4 #logo {
+  background-position: left bottom 30px;
+}
+/* line 361, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-contrast #header #logo a {
   display: inline-block;
 }
-/* line 277, ../sass/stanford_jumpstart_home.scss */
+/* line 364, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-contrast #header #logo img {
   left: -1000px;
   position: relative;
   top: -1000px;
 }
 
-/* line 284, ../sass/stanford_jumpstart_home.scss */
+/* line 372, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-dark .navbar {
   background: #282724;
 }
-/* line 287, ../sass/stanford_jumpstart_home.scss */
+/* line 375, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-dark #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #282724;
 }
-/* line 296, ../sass/stanford_jumpstart_home.scss */
+/* line 384, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > .active > a,
 .stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > .active > a:hover,
 .stanford-jumpstart-home-palm.style-custom-styles-dark .site-main-menu .navbar .nav > .active > a:focus,
@@ -313,15 +394,15 @@
   border: 0;
 }
 
-/* line 304, ../sass/stanford_jumpstart_home.scss */
+/* line 393, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-light .navbar {
   background: #f8f7f2;
 }
-/* line 307, ../sass/stanford_jumpstart_home.scss */
+/* line 396, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-light #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #f8f7f2;
 }
-/* line 316, ../sass/stanford_jumpstart_home.scss */
+/* line 405, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-light .site-main-menu .navbar .nav > .active > a,
 .stanford-jumpstart-home-palm.style-custom-styles-light .site-main-menu .navbar .nav > .active > a:hover,
 .stanford-jumpstart-home-palm.style-custom-styles-light .site-main-menu .navbar .nav > .active > a:focus,
@@ -333,15 +414,15 @@
   border: 0;
 }
 
-/* line 324, ../sass/stanford_jumpstart_home.scss */
+/* line 414, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-plain .navbar {
   background: #e9e9e9;
 }
-/* line 327, ../sass/stanford_jumpstart_home.scss */
+/* line 417, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-plain #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #e9e9e9;
 }
-/* line 336, ../sass/stanford_jumpstart_home.scss */
+/* line 426, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > .active > a,
 .stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > .active > a:hover,
 .stanford-jumpstart-home-palm.style-custom-styles-plain .site-main-menu .navbar .nav > .active > a:focus,
@@ -353,15 +434,15 @@
   border: 0;
 }
 
-/* line 344, ../sass/stanford_jumpstart_home.scss */
+/* line 435, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-rich .navbar {
   background: #d5d0c0;
 }
-/* line 347, ../sass/stanford_jumpstart_home.scss */
+/* line 438, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-rich #block-bean-jumpstart-homepage-tall-banner .border-simple img {
   background-color: #d5d0c0;
 }
-/* line 356, ../sass/stanford_jumpstart_home.scss */
+/* line 447, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > .active > a,
 .stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > .active > a:hover,
 .stanford-jumpstart-home-palm.style-custom-styles-rich .site-main-menu .navbar .nav > .active > a:focus,
@@ -374,62 +455,65 @@
 }
 
 /** LAYOUT: SERRA ************************
-	- Color background on header
-	- Big text block
-	- Infotext block
-	- Two-column mission text blocks 
-	- Three blocks
+    - Color background on header
+    - Big text block
+    - Infotext block
+    - Two-column mission text blocks
+    - Three blocks
 ******************************************/
-/* line 374, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra .site-main-menu, .stanford-jumpstart-home-serra .navbar {
+/* line 466, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra .site-main-menu,
+.stanford-jumpstart-home-serra .navbar {
   background: transparent;
 }
-/* line 377, ../sass/stanford_jumpstart_home.scss */
+/* line 469, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .main {
   padding-top: 0;
 }
-/* line 380, ../sass/stanford_jumpstart_home.scss */
+/* line 472, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .site-main-menu {
   border: 0;
 }
-/* line 383, ../sass/stanford_jumpstart_home.scss */
+/* line 475, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .main-top {
   padding-top: 2em;
   margin-bottom: 2em;
 }
-/* line 387, ../sass/stanford_jumpstart_home.scss */
+/* line 479, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra .mission-block {
   font-size: 1.3em;
   line-height: 1.4em;
 }
-/* line 391, ../sass/stanford_jumpstart_home.scss */
+/* line 483, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra #block-bean-jumpstart-info-text-block {
   margin-left: 16%;
 }
 @media (max-width: 767px) {
-  /* line 391, ../sass/stanford_jumpstart_home.scss */
+  /* line 483, ../sass/stanford_jumpstart_home.scss */
   .stanford-jumpstart-home-serra #block-bean-jumpstart-info-text-block {
     margin-left: 0;
   }
 }
 
-/* line 399, ../sass/stanford_jumpstart_home.scss */
+/* line 492, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top {
   border-bottom: 1px solid #53284f;
 }
-/* line 402, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra.style-custom-styles-bright .main-top, .stanford-jumpstart-home-serra.style-custom-styles-bright .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-bright .header {
+/* line 497, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra.style-custom-styles-bright .main-top,
+.stanford-jumpstart-home-serra.style-custom-styles-bright .site-main-menu,
+.stanford-jumpstart-home-serra.style-custom-styles-bright .header {
   background: #53284f;
   color: white;
 }
-/* line 409, ../sass/stanford_jumpstart_home.scss */
+/* line 504, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .more-link a,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top a.more-link,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .big-text,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .infotext {
   color: #ffce49;
 }
-/* line 415, ../sass/stanford_jumpstart_home.scss */
+/* line 510, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .more-link a:hover,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top .more-link a:focus,
 .stanford-jumpstart-home-serra.style-custom-styles-bright .main-top a.more-link:hover,
@@ -438,23 +522,25 @@
   text-decoration: underline;
 }
 
-/* line 421, ../sass/stanford_jumpstart_home.scss */
+/* line 517, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top {
   border-bottom: 1px solid #8c1515;
 }
-/* line 424, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top, .stanford-jumpstart-home-serra.style-custom-styles-cardinal .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-cardinal .header {
+/* line 522, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top,
+.stanford-jumpstart-home-serra.style-custom-styles-cardinal .site-main-menu,
+.stanford-jumpstart-home-serra.style-custom-styles-cardinal .header {
   background: #8c1515;
   color: white;
 }
-/* line 431, ../sass/stanford_jumpstart_home.scss */
+/* line 529, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .more-link a,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top a.more-link,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .big-text,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .infotext {
   color: white;
 }
-/* line 437, ../sass/stanford_jumpstart_home.scss */
+/* line 535, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .more-link a:hover,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top .more-link a:focus,
 .stanford-jumpstart-home-serra.style-custom-styles-cardinal .main-top a.more-link:hover,
@@ -463,23 +549,25 @@
   text-decoration: underline;
 }
 
-/* line 443, ../sass/stanford_jumpstart_home.scss */
+/* line 542, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top {
   border-bottom: 1px solid transparent;
 }
-/* line 446, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top, .stanford-jumpstart-home-serra.style-custom-styles-contrast .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-contrast .header {
+/* line 547, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top,
+.stanford-jumpstart-home-serra.style-custom-styles-contrast .site-main-menu,
+.stanford-jumpstart-home-serra.style-custom-styles-contrast .header {
   background: #333333;
   color: white;
 }
-/* line 453, ../sass/stanford_jumpstart_home.scss */
+/* line 554, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .more-link a,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top a.more-link,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .big-text,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .infotext {
   color: #b3995d;
 }
-/* line 459, ../sass/stanford_jumpstart_home.scss */
+/* line 560, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .more-link a:hover,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top .more-link a:focus,
 .stanford-jumpstart-home-serra.style-custom-styles-contrast .main-top a.more-link:hover,
@@ -488,44 +576,52 @@
   text-decoration: underline;
 }
 
-/* line 465, ../sass/stanford_jumpstart_home.scss */
+/* line 567, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-dark .main-top {
   border-bottom: 1px solid #232220;
 }
-/* line 468, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra.style-custom-styles-dark .main-top, .stanford-jumpstart-home-serra.style-custom-styles-dark .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-dark .header {
+/* line 572, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra.style-custom-styles-dark .main-top,
+.stanford-jumpstart-home-serra.style-custom-styles-dark .site-main-menu,
+.stanford-jumpstart-home-serra.style-custom-styles-dark .header {
   background: #282724;
 }
 
-/* line 473, ../sass/stanford_jumpstart_home.scss */
+/* line 578, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-light .main-top {
   border-bottom: 1px solid #e9e6df;
 }
-/* line 476, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra.style-custom-styles-light .main-top, .stanford-jumpstart-home-serra.style-custom-styles-light .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-light .header {
+/* line 583, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra.style-custom-styles-light .main-top,
+.stanford-jumpstart-home-serra.style-custom-styles-light .site-main-menu,
+.stanford-jumpstart-home-serra.style-custom-styles-light .header {
   background: #f8f7f2;
 }
 
-/* line 481, ../sass/stanford_jumpstart_home.scss */
+/* line 589, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-plain .main-top {
   border-bottom: 1px solid transparent;
 }
-/* line 484, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra.style-custom-styles-plain .main-top, .stanford-jumpstart-home-serra.style-custom-styles-plain .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-plain .header {
+/* line 594, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra.style-custom-styles-plain .main-top,
+.stanford-jumpstart-home-serra.style-custom-styles-plain .site-main-menu,
+.stanford-jumpstart-home-serra.style-custom-styles-plain .header {
   background: white;
 }
 
-/* line 489, ../sass/stanford_jumpstart_home.scss */
+/* line 600, ../sass/stanford_jumpstart_home.scss */
 .stanford-jumpstart-home-serra.style-custom-styles-rich .main-top {
   border-bottom: 1px solid #d5d0c0;
 }
-/* line 492, ../sass/stanford_jumpstart_home.scss */
-.stanford-jumpstart-home-serra.style-custom-styles-rich .main-top, .stanford-jumpstart-home-serra.style-custom-styles-rich .site-main-menu, .stanford-jumpstart-home-serra.style-custom-styles-rich .header {
+/* line 605, ../sass/stanford_jumpstart_home.scss */
+.stanford-jumpstart-home-serra.style-custom-styles-rich .main-top,
+.stanford-jumpstart-home-serra.style-custom-styles-rich .site-main-menu,
+.stanford-jumpstart-home-serra.style-custom-styles-rich .header {
   background: #d5d0c0;
 }
 
 /** LAYOUT: PANAMA ************************
-	- About block
-	- Banner image with overlay 
-	- Three blocks
+    - About block
+    - Banner image with overlay
+    - Three blocks
 ******************************************/

--- a/sass/stanford_jumpstart_home.scss
+++ b/sass/stanford_jumpstart_home.scss
@@ -1,507 +1,617 @@
 /** SASS ****************************/
-@import
-	"compass/css3",
-	"variables/variables",
-	"variables/bright-variables",
-	"variables/cardinal-variables",
-	"variables/contrast-variables",
-	"variables/dark-variables",
-	"variables/light-variables",
-	"variables/plain-variables",
-	"variables/rich-variables";
+
+@import "compass/css3",
+"variables/variables",
+"variables/bright-variables",
+"variables/cardinal-variables",
+"variables/contrast-variables",
+"variables/dark-variables",
+"variables/light-variables",
+"variables/plain-variables",
+"variables/rich-variables";
 
 /** GENERAL ****************************/
 
 .bean-stanford-testimonial-block .quote {
-	margin-top: -34px;
-	.field-item:after {
-		font-size: 40px;
-	    font-weight: bold;
-	    opacity: 0.5;
-	    content: close-quote;
-	    line-height: 0;
-	    position: relative;
-	    left: 8px;
-	    top: 20px;
-	}
+    margin-top: -34px;
+    .field-item:after {
+        font-size: 40px;
+        font-weight: bold;
+        opacity: 0.5;
+        content: close-quote;
+        line-height: 0;
+        position: relative;
+        left: 8px;
+        top: 20px;
+    }
 }
 
+
 /** LAYOUT: LOMITA ************************
-	- Full-bleed background image
-	- Big text block
-	- Video block
+    - Full-bleed background image
+    - Big text block
+    - Video block
 ******************************************/
 
 .stanford-jumpstart-home-lomita {
-	.content-top .block {
-		border: none;
-		padding: 1em;
-	    @include border-radius(0);
-	    @include box-shadow(none);
-	}
+    .content-top .block {
+        border: none;
+        padding: 1em;
+        @include border-radius(0);
+        @include box-shadow(none);
+    }
 }
+
 .stanford-jumpstart-home-lomita.style-custom-styles-bright {
-	.navbar {
-		background: $bright_clr-header-bkg;
-	}
-	.content-top .block {
-		background: $bright_clr-well-bkg;
-		color: $bright_clr-page-bkg;
-	}
-	.site-footer {
-		background: $bright_clr-footer-bkg;
-	}
+    .navbar {
+        background: $bright_clr-header-bkg;
+    }
+    .content-top .block {
+        background: $bright_clr-well-bkg;
+        color: $bright_clr-page-bkg;
+    }
+    .site-footer {
+        background: $bright_clr-footer-bkg;
+    }
 }
+
 .stanford-jumpstart-home-lomita.style-custom-styles-cardinal {
-	.navbar {
-		background: $cardinal_clr-header-bkg;
-	}
-	.content-top .block {
-		background: $cardinal_clr-well-bkg;
-		color: $cardinal_clr-page-bkg;
-	}
-	.site-footer {
-		background: $cardinal_clr-footer-bkg;
-	}
+    .navbar {
+        background: $cardinal_clr-header-bkg;
+    }
+    .content-top .block {
+        background: $cardinal_clr-well-bkg;
+        color: $cardinal_clr-page-bkg;
+    }
+    .site-footer {
+        background: $cardinal_clr-footer-bkg;
+    }
 }
+
 .stanford-jumpstart-home-lomita.style-custom-styles-contrast {
-	.navbar {
-		background: $contrast_clr-header-bkg;
-	}
-	.content-top .block {
-		background: $contrast_clr-well-bkg;
-		color: $contrast_clr-page-bkg;
-	}
-	.site-footer {
-		background: $contrast_clr-footer-bkg;
-	}
+    .navbar {
+        background: $contrast_clr-header-bkg;
+    }
+    .content-top .block {
+        background: $contrast_clr-well-bkg;
+        color: $contrast_clr-page-bkg;
+    }
+    .site-footer {
+        background: $contrast_clr-footer-bkg;
+    }
 }
+
 .stanford-jumpstart-home-lomita.style-custom-styles-dark {
-	.navbar {
-		background: $dark_clr-header-bkg;
-	}
-	.content-top .block {
-		background: $dark_clr-well-bkg;
-		color: $dark_clr-page-bkg;
-	}
-	.site-footer {
-		background: $dark_clr-footer-bkg;
-	}
+    .navbar {
+        background: $dark_clr-header-bkg;
+    }
+    .content-top .block {
+        background: $dark_clr-well-bkg;
+        color: $dark_clr-page-bkg;
+    }
+    .site-footer {
+        background: $dark_clr-footer-bkg;
+    }
 }
+
 .stanford-jumpstart-home-lomita.style-custom-styles-light {
-	.navbar {
-		background: $light_clr-header-bkg;
-	}
-	.content-top .block {
-		background: $light_clr-well-bkg;
-		color: $light_clr-page-bkg;
-	}
-	.site-footer {
-		background: $light_clr-footer-bkg;
-	}
+    .navbar {
+        background: $light_clr-header-bkg;
+    }
+    .content-top .block {
+        background: $light_clr-well-bkg;
+        color: $light_clr-page-bkg;
+    }
+    .site-footer {
+        background: $light_clr-footer-bkg;
+    }
 }
+
 .stanford-jumpstart-home-lomita.style-custom-styles-plain {
-	.navbar {
-		background: $plain_clr-header-bkg;
-	}
-	.content-top .block {
-		background: $plain_clr-well-bkg;
-		color: $plain_clr-page-bkg;
-	}
-	.site-footer {
-		background: $plain_clr-footer-bkg;
-	}
+    .navbar {
+        background: $plain_clr-header-bkg;
+    }
+    .content-top .block {
+        background: $plain_clr-well-bkg;
+        color: $plain_clr-page-bkg;
+    }
+    .site-footer {
+        background: $plain_clr-footer-bkg;
+    }
 }
+
 .stanford-jumpstart-home-lomita.style-custom-styles-rich {
-	.navbar {
-		background: $rich_clr-header-bkg;
-	}
-	.content-top .block {
-		background: $rich_clr-well-bkg;
-		color: $rich_clr-page-bkg;
-	}
-	.site-footer {
-		background: $rich_clr-footer-bkg;
-	}
+    .navbar {
+        background: $rich_clr-header-bkg;
+    }
+    .content-top .block {
+        background: $rich_clr-well-bkg;
+        color: $rich_clr-page-bkg;
+    }
+    .site-footer {
+        background: $rich_clr-footer-bkg;
+    }
 }
 
 
 /** LAYOUT: MAYFIELD ************************
-	- Header background image
-	- Big text block
-	- Quote block
-	- Three blocks
+    - Header background image
+    - Big text block
+    - Quote block
+    - Three blocks
 ******************************************/
 
 .stanford-jumpstart-home-mayfield {
-	#block-bean-jumpstart-lead-text-with-body {
-		padding-right: 2em;	
-	}
-	.bean-stanford-testimonial-block {
-	    margin-left: 2em;
-	}
-	@media (max-width: 767px) {
-		.bean-stanford-testimonial-block .postcard-right > div {
-			display: block;
-		}
-		.bean-stanford-testimonial-block .postcard-right > div:first-child {
-			float: none;
-		}
-		.bean-stanford-testimonial-block .postcard-right > div:first-child img {
-			margin: 0;
-		}
-	}
-	@media (max-width: 480px) {
-		#block-bean-jumpstart-lead-text-with-body {
-			padding-right: 0;	
-		}
-		.bean-stanford-testimonial-block {
-		    margin-left: 0;
-		}
-	}
+    #block-bean-jumpstart-lead-text-with-body {
+        padding-right: 2em;
+    }
+    .bean-stanford-testimonial-block {
+        margin-left: 2em;
+    }
+    @media (max-width: 767px) {
+        .bean-stanford-testimonial-block .postcard-right > div {
+            display: block;
+        }
+        .bean-stanford-testimonial-block .postcard-right > div:first-child {
+            float: none;
+        }
+        .bean-stanford-testimonial-block .postcard-right > div:first-child img {
+            margin: 0;
+        }
+    }
+    @media (max-width: 480px) {
+        #block-bean-jumpstart-lead-text-with-body {
+            padding-right: 0;
+        }
+        .bean-stanford-testimonial-block {
+            margin-left: 0;
+        }
+    }
 }
-.stanford-jumpstart-home-mayfield.style-custom-styles-bright {
-}
-.stanford-jumpstart-home-mayfield.style-custom-styles-cardinal {
-}
-.stanford-jumpstart-home-mayfield.style-custom-styles-contrast {
-}
-.stanford-jumpstart-home-mayfield.style-custom-styles-dark {
-}
-.stanford-jumpstart-home-mayfield.style-custom-styles-light {
-}
-.stanford-jumpstart-home-mayfield.style-custom-styles-plain {
-}
-.stanford-jumpstart-home-mayfield.style-custom-styles-rich {
-}
+
+.stanford-jumpstart-home-mayfield.style-custom-styles-bright {}
+
+.stanford-jumpstart-home-mayfield.style-custom-styles-cardinal {}
+
+.stanford-jumpstart-home-mayfield.style-custom-styles-contrast {}
+
+.stanford-jumpstart-home-mayfield.style-custom-styles-dark {}
+
+.stanford-jumpstart-home-mayfield.style-custom-styles-light {}
+
+.stanford-jumpstart-home-mayfield.style-custom-styles-plain {}
+
+.stanford-jumpstart-home-mayfield.style-custom-styles-rich {}
 
 
 /** LAYOUT: PALM ************************
-	- 12-column banner with overlay
-	- Three blocks
-	- Menu not full width
+    - 12-column banner with overlay
+    - Three blocks
+    - Menu not full width
 ******************************************/
 
 .stanford-jumpstart-home-palm {
-	.site-main-menu {
-		background: transparent;
-		border: 0;
-	}
-	.navbar {
-		padding: 0.5em;
-		margin: 0;
-	    .nav > li > a {
-	        padding: 0.25em 0.5em;
-	        border: 0;
-        	margin-right: 0.5em;
-	    }
-	}
-	.header {
-		background: transparent;
-	}
+    .site-main-menu {
+        background: transparent;
+        border: 0;
+    }
+    .navbar {
+        padding: 0.5em;
+        margin: 0;
+        .nav > li > a {
+            padding: 0.25em 0.5em;
+            border: 0;
+            margin-right: 0.5em;
+        }
+    }
+    .header {
+        background: transparent;
+    }
 }
+
 .front.stanford-jumpstart-home-palm {
-	.main {
-		padding-top: 0;
-	}
+    .main {
+        padding-top: 0;
+    }
 }
+
 .stanford-jumpstart-home-palm.style-custom-styles-bright {
-	.navbar {
-		background: $bright_clr-header-bkg;
-	}
-	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
-		background-color: $bright_clr-header-bkg;
-	}
-	#site-name a, #site-name a:hover, #site-name a, #site-name a:focus, #site-title-first-line a, #site-title-first-line a:hover, #site-title-first-line a:focus, #site-title-second-line a, #site-title-second-line a:hover, #site-title-second-line a:focus {
-		color: $cardinal_clr-text;
-	}
-	#header #logo {
-		border-right: 1px solid $cardinal_clr-text;
-		background-image: url("../../../../themes/stanford_framework/logo.png");
-		background-repeat: no-repeat;
-		background-size: 180px auto;
-	}
-	#header #logo a {
-		display: inline-block;
-	}
-	#header #logo img {
-	    left: -1000px;
-	    position: relative;
-	    top: -1000px;
-	}
+    .navbar {
+        background: $bright_clr-header-bkg;
+    }
+    #block-bean-jumpstart-homepage-tall-banner .border-simple img {
+        background-color: $bright_clr-header-bkg;
+    }
+    #site-name a,
+    #site-name a:hover,
+    #site-name a,
+    #site-name a:focus,
+    #site-title-first-line a,
+    #site-title-first-line a:hover,
+    #site-title-first-line a:focus,
+    #site-title-second-line a,
+    #site-title-second-line a:hover,
+    #site-title-second-line a:focus,
+    #site-title-line3 a,
+    #site-title-line3 a:hover,
+    #site-title-line3 a:focus,
+    #site-title-line4 a,
+    #site-title-line4 a:hover,
+    #site-title-line4 a:focus,
+    #site-title-line5 a,
+    #site-title-line5 a:hover,
+    #site-title-line5 a:focus {
+        color: $cardinal_clr-text;
+    }
+    #header #logo {
+        border-right: 1px solid $cardinal_clr-text;
+        background-image: url("../../../../themes/stanford_framework/logo.png");
+        background-repeat: no-repeat;
+        background-size: 180px auto;
+        background-position: left bottom;
+    }
+    #header #logo.site-logo {
+        border: none;
+    }
+    #header.line4 #logo {
+        background-position: left bottom 30px;
+    }
+    #header #logo a {
+        display: inline-block;
+    }
+    #header #logo img {
+        left: -1000px;
+        position: relative;
+        top: -1000px;
+    }
 }
+
 .stanford-jumpstart-home-palm.style-custom-styles-cardinal {
-	.navbar {
-		background: $cardinal_clr-header-bkg;
-	}
-	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
-		background-color: $cardinal_clr-header-bkg;
-	}
-	#site-name a, #site-name a:hover, #site-name a, #site-name a:focus, #site-title-first-line a, #site-title-first-line a:hover, #site-title-first-line a:focus, #site-title-second-line a, #site-title-second-line a:hover, #site-title-second-line a:focus {
-		color: $cardinal_clr-text;
-	}
-	#header #logo {
-		border-right: 1px solid $cardinal_clr-text;
-		background-image: url("../../../../themes/stanford_framework/logo.png");
-		background-repeat: no-repeat;
-		background-size: 180px auto;
-	}
-	#header #logo a {
-		display: inline-block;
-	}
-	#header #logo img {
-	    left: -1000px;
-	    position: relative;
-	    top: -1000px;
-	}
+    .navbar {
+        background: $cardinal_clr-header-bkg;
+    }
+    #block-bean-jumpstart-homepage-tall-banner .border-simple img {
+        background-color: $cardinal_clr-header-bkg;
+    }
+    #site-name a,
+    #site-name a:hover,
+    #site-name a,
+    #site-name a:focus,
+    #site-title-first-line a,
+    #site-title-first-line a:hover,
+    #site-title-first-line a:focus,
+    #site-title-second-line a,
+    #site-title-second-line a:hover,
+    #site-title-second-line a:focus,
+    #site-title-line3 a,
+    #site-title-line3 a:hover,
+    #site-title-line3 a:focus,
+    #site-title-line4 a,
+    #site-title-line4 a:hover,
+    #site-title-line4 a:focus,
+    #site-title-line5 a,
+    #site-title-line5 a:hover,
+    #site-title-line5 a:focus {
+        color: $cardinal_clr-text;
+    }
+    #header #logo {
+        border-right: 1px solid $cardinal_clr-text;
+        background-image: url("../../../../themes/stanford_framework/logo.png");
+        background-repeat: no-repeat;
+        background-size: 180px auto;
+        background-position: left bottom;
+    }
+    #header #logo.site-logo {
+        border: none;
+    }
+    #header.line4 #logo {
+        background-position: left bottom 30px;
+    }
+    #header #logo a {
+        display: inline-block;
+    }
+    #header #logo img {
+        left: -1000px;
+        position: relative;
+        top: -1000px;
+    }
 }
+
 .stanford-jumpstart-home-palm.style-custom-styles-contrast {
-	.navbar {
-		background: $contrast_clr-header-bkg;
-	}
-	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
-		background-color: $contrast_clr-header-bkg;
-	}
-	#site-name a, #site-name a:hover, #site-name a, #site-name a:focus, #site-title-first-line a, #site-title-first-line a:hover, #site-title-first-line a:focus, #site-title-second-line a, #site-title-second-line a:hover, #site-title-second-line a:focus {
-		color: $cardinal_clr-text;
-	}
-	#header #logo {
-		border-right: 1px solid $cardinal_clr-text;
-		background-image: url("../../../../themes/stanford_framework/logo.png");
-		background-repeat: no-repeat;
-		background-size: 180px auto;
-	}
-	#header #logo a {
-		display: inline-block;
-	}
-	#header #logo img {
-	    left: -1000px;
-	    position: relative;
-	    top: -1000px;
-	}
+    .navbar {
+        background: $contrast_clr-header-bkg;
+    }
+    #block-bean-jumpstart-homepage-tall-banner .border-simple img {
+        background-color: $contrast_clr-header-bkg;
+    }
+    #site-name a,
+    #site-name a:hover,
+    #site-name a,
+    #site-name a:focus,
+    #site-title-first-line a,
+    #site-title-first-line a:hover,
+    #site-title-first-line a:focus,
+    #site-title-second-line a,
+    #site-title-second-line a:hover,
+    #site-title-second-line a:focus,
+    #site-title-line3 a,
+    #site-title-line3 a:hover,
+    #site-title-line3 a:focus,
+    #site-title-line4 a,
+    #site-title-line4 a:hover,
+    #site-title-line4 a:focus,
+    #site-title-line5 a,
+    #site-title-line5 a:hover,
+    #site-title-line5 a:focus {
+        color: $cardinal_clr-text;
+    }
+    #header #logo {
+        border-right: 1px solid $cardinal_clr-text;
+        background-image: url("../../../../themes/stanford_framework/logo.png");
+        background-repeat: no-repeat;
+        background-size: 180px auto;
+        background-position: left bottom;
+    }
+    #header #logo.site-logo {
+        border: none;
+    }
+    #header.line4 #logo {
+        background-position: left bottom 30px;
+    }
+    #header #logo a {
+        display: inline-block;
+    }
+    #header #logo img {
+        left: -1000px;
+        position: relative;
+        top: -1000px;
+    }
 }
+
 .stanford-jumpstart-home-palm.style-custom-styles-dark {
-	.navbar {
-		background: $dark_clr-header-bkg;
-	}
-	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
-		background-color: $dark_clr-header-bkg;
-	}
-	.site-main-menu {
-	    .navbar .nav > .active > a, 
-	    .navbar .nav > .active > a:hover, 
-	    .navbar .nav > .active > a:focus, 
-	    .navbar .nav > li > a:focus, 
-	    .navbar .nav > li > a:hover,
-	    .navbar .nav > .active-trail > a {
-	        color: $dark_clr-header-bkg;
-	        background: $dark_clr-menu-text-hvr;
-	        border: 0;
-	    }
-	}
+    .navbar {
+        background: $dark_clr-header-bkg;
+    }
+    #block-bean-jumpstart-homepage-tall-banner .border-simple img {
+        background-color: $dark_clr-header-bkg;
+    }
+    .site-main-menu {
+        .navbar .nav > .active > a,
+        .navbar .nav > .active > a:hover,
+        .navbar .nav > .active > a:focus,
+        .navbar .nav > li > a:focus,
+        .navbar .nav > li > a:hover,
+        .navbar .nav > .active-trail > a {
+            color: $dark_clr-header-bkg;
+            background: $dark_clr-menu-text-hvr;
+            border: 0;
+        }
+    }
 }
+
 .stanford-jumpstart-home-palm.style-custom-styles-light {
-	.navbar {
-		background: $light_clr-header-bkg;
-	}
-	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
-		background-color: $light_clr-header-bkg;
-	}
-	.site-main-menu {
-	    .navbar .nav > .active > a, 
-	    .navbar .nav > .active > a:hover, 
-	    .navbar .nav > .active > a:focus, 
-	    .navbar .nav > li > a:focus, 
-	    .navbar .nav > li > a:hover,
-	    .navbar .nav > .active-trail > a {
-	        color: $light_clr-menu-text-hvr;
-	        background: $light_clr-menu-link-border;
-	        border: 0;
-	    }
-	}
+    .navbar {
+        background: $light_clr-header-bkg;
+    }
+    #block-bean-jumpstart-homepage-tall-banner .border-simple img {
+        background-color: $light_clr-header-bkg;
+    }
+    .site-main-menu {
+        .navbar .nav > .active > a,
+        .navbar .nav > .active > a:hover,
+        .navbar .nav > .active > a:focus,
+        .navbar .nav > li > a:focus,
+        .navbar .nav > li > a:hover,
+        .navbar .nav > .active-trail > a {
+            color: $light_clr-menu-text-hvr;
+            background: $light_clr-menu-link-border;
+            border: 0;
+        }
+    }
 }
+
 .stanford-jumpstart-home-palm.style-custom-styles-plain {
-	.navbar {
-		background: $plain_clr-well-bkg;
-	}
-	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
-		background-color: $plain_clr-well-bkg;
-	}
-	.site-main-menu {
-	    .navbar .nav > .active > a, 
-	    .navbar .nav > .active > a:hover, 
-	    .navbar .nav > .active > a:focus, 
-	    .navbar .nav > li > a:focus, 
-	    .navbar .nav > li > a:hover,
-	    .navbar .nav > .active-trail > a {
-	        color: $plain_clr-page-bkg;
-	        background: $plain_clr-menu-text-hvr;
-	        border: 0;
-	    }
-	}
+    .navbar {
+        background: $plain_clr-well-bkg;
+    }
+    #block-bean-jumpstart-homepage-tall-banner .border-simple img {
+        background-color: $plain_clr-well-bkg;
+    }
+    .site-main-menu {
+        .navbar .nav > .active > a,
+        .navbar .nav > .active > a:hover,
+        .navbar .nav > .active > a:focus,
+        .navbar .nav > li > a:focus,
+        .navbar .nav > li > a:hover,
+        .navbar .nav > .active-trail > a {
+            color: $plain_clr-page-bkg;
+            background: $plain_clr-menu-text-hvr;
+            border: 0;
+        }
+    }
 }
+
 .stanford-jumpstart-home-palm.style-custom-styles-rich {
-	.navbar {
-		background: $rich_clr-header-bkg;
-	}
-	#block-bean-jumpstart-homepage-tall-banner .border-simple img {
-		background-color: $rich_clr-header-bkg;
-	}
-	.site-main-menu {
-	    .navbar .nav > .active > a, 
-	    .navbar .nav > .active > a:hover, 
-	    .navbar .nav > .active > a:focus, 
-	    .navbar .nav > li > a:focus, 
-	    .navbar .nav > li > a:hover,
-	    .navbar .nav > .active-trail > a {
-	        color: $rich_clr-page-bkg;
-	        background: $rich_clr-menu-link-border;
-	        border: 0;
-	    }
-	}
+    .navbar {
+        background: $rich_clr-header-bkg;
+    }
+    #block-bean-jumpstart-homepage-tall-banner .border-simple img {
+        background-color: $rich_clr-header-bkg;
+    }
+    .site-main-menu {
+        .navbar .nav > .active > a,
+        .navbar .nav > .active > a:hover,
+        .navbar .nav > .active > a:focus,
+        .navbar .nav > li > a:focus,
+        .navbar .nav > li > a:hover,
+        .navbar .nav > .active-trail > a {
+            color: $rich_clr-page-bkg;
+            background: $rich_clr-menu-link-border;
+            border: 0;
+        }
+    }
 }
 
 
 /** LAYOUT: SERRA ************************
-	- Color background on header
-	- Big text block
-	- Infotext block
-	- Two-column mission text blocks 
-	- Three blocks
+    - Color background on header
+    - Big text block
+    - Infotext block
+    - Two-column mission text blocks
+    - Three blocks
 ******************************************/
 
 .stanford-jumpstart-home-serra {
-	.site-main-menu, .navbar {
-		background: transparent;
-	}
-	.main {
-		padding-top: 0;
-	}
-	.site-main-menu {
-		border: 0;
-	}
-	.main-top {
-		padding-top: 2em;
-		margin-bottom: 2em;
-	}
-	.mission-block {
-		font-size: 1.3em;
-		line-height: 1.4em;
-	}
-	#block-bean-jumpstart-info-text-block {
-		margin-left: 16%;
-		@media (max-width: 767px) {
-	        margin-left: 0;
-	    }
-	}
-}
-.stanford-jumpstart-home-serra.style-custom-styles-bright {
-	.main-top {
-		border-bottom: 1px solid $bright_clr-line;
-	}
-	.main-top, .site-main-menu, .header {
-		background: $bright_clr-header-bkg;
-		color: $bright_clr-page-bkg;
-	}
-	.main-top .more-link a,
-	.main-top a.more-link,
-	.main-top .big-text,
-	.main-top .infotext {
-		color: #ffce49;
-	}
-	.main-top .more-link a:hover,
-	.main-top .more-link a:focus,
-	.main-top a.more-link:hover,
-	.main-top a.more-link:focus {
-		color: $bright_clr-page-bkg;
-		text-decoration: underline;
-	} 
-}
-.stanford-jumpstart-home-serra.style-custom-styles-cardinal {
-	.main-top {
-		border-bottom: 1px solid $cardinal_clr-line;
-	}
-	.main-top, .site-main-menu, .header {
-		background: $cardinal_clr-header-bkg;
-		color: $cardinal_clr-page-bkg;
-	}
-	.main-top .more-link a,
-	.main-top a.more-link,
-	.main-top .big-text,
-	.main-top .infotext {
-		color: $cardinal_clr-page-bkg;
-	}
-	.main-top .more-link a:hover,
-	.main-top .more-link a:focus,
-	.main-top a.more-link:hover,
-	.main-top a.more-link:focus {
-		color: $cardinal_clr-page-bkg;
-		text-decoration: underline;
-	}
-}
-.stanford-jumpstart-home-serra.style-custom-styles-contrast {
-	.main-top {
-		border-bottom: 1px solid $contrast_clr-line;
-	}
-	.main-top, .site-main-menu, .header {
-		background: $contrast_clr-header-bkg;
-		color: $contrast_clr-page-bkg;
-	}
-	.main-top .more-link a,
-	.main-top a.more-link,
-	.main-top .big-text,
-	.main-top .infotext {
-		color: #b3995d;
-	}
-	.main-top .more-link a:hover,
-	.main-top .more-link a:focus,
-	.main-top a.more-link:hover,
-	.main-top a.more-link:focus {
-		color: $contrast_clr-page-bkg;
-		text-decoration: underline;
-	} 
-}
-.stanford-jumpstart-home-serra.style-custom-styles-dark {
-	.main-top {
-		border-bottom: 1px solid $dark_clr-line;
-	}
-	.main-top, .site-main-menu, .header {
-		background: $dark_clr-header-bkg;
-	}
-}
-.stanford-jumpstart-home-serra.style-custom-styles-light {
-	.main-top {
-		border-bottom: 1px solid $light_clr-line;
-	}
-	.main-top, .site-main-menu, .header {
-		background: $light_clr-header-bkg;
-	}
-}
-.stanford-jumpstart-home-serra.style-custom-styles-plain {
-	.main-top {
-		border-bottom: 1px solid $plain_clr-line;
-	}
-	.main-top, .site-main-menu, .header {
-		background: $plain_clr-header-bkg;
-	}
-}
-.stanford-jumpstart-home-serra.style-custom-styles-rich {
-	.main-top {
-		border-bottom: 1px solid $rich_clr-line;
-	}
-	.main-top, .site-main-menu, .header {
-		background: $rich_clr-header-bkg;
-	}
+    .site-main-menu,
+    .navbar {
+        background: transparent;
+    }
+    .main {
+        padding-top: 0;
+    }
+    .site-main-menu {
+        border: 0;
+    }
+    .main-top {
+        padding-top: 2em;
+        margin-bottom: 2em;
+    }
+    .mission-block {
+        font-size: 1.3em;
+        line-height: 1.4em;
+    }
+    #block-bean-jumpstart-info-text-block {
+        margin-left: 16%;
+        @media (max-width: 767px) {
+            margin-left: 0;
+        }
+    }
 }
 
+.stanford-jumpstart-home-serra.style-custom-styles-bright {
+    .main-top {
+        border-bottom: 1px solid $bright_clr-line;
+    }
+    .main-top,
+    .site-main-menu,
+    .header {
+        background: $bright_clr-header-bkg;
+        color: $bright_clr-page-bkg;
+    }
+    .main-top .more-link a,
+    .main-top a.more-link,
+    .main-top .big-text,
+    .main-top .infotext {
+        color: #ffce49;
+    }
+    .main-top .more-link a:hover,
+    .main-top .more-link a:focus,
+    .main-top a.more-link:hover,
+    .main-top a.more-link:focus {
+        color: $bright_clr-page-bkg;
+        text-decoration: underline;
+    }
+}
+
+.stanford-jumpstart-home-serra.style-custom-styles-cardinal {
+    .main-top {
+        border-bottom: 1px solid $cardinal_clr-line;
+    }
+    .main-top,
+    .site-main-menu,
+    .header {
+        background: $cardinal_clr-header-bkg;
+        color: $cardinal_clr-page-bkg;
+    }
+    .main-top .more-link a,
+    .main-top a.more-link,
+    .main-top .big-text,
+    .main-top .infotext {
+        color: $cardinal_clr-page-bkg;
+    }
+    .main-top .more-link a:hover,
+    .main-top .more-link a:focus,
+    .main-top a.more-link:hover,
+    .main-top a.more-link:focus {
+        color: $cardinal_clr-page-bkg;
+        text-decoration: underline;
+    }
+}
+
+.stanford-jumpstart-home-serra.style-custom-styles-contrast {
+    .main-top {
+        border-bottom: 1px solid $contrast_clr-line;
+    }
+    .main-top,
+    .site-main-menu,
+    .header {
+        background: $contrast_clr-header-bkg;
+        color: $contrast_clr-page-bkg;
+    }
+    .main-top .more-link a,
+    .main-top a.more-link,
+    .main-top .big-text,
+    .main-top .infotext {
+        color: #b3995d;
+    }
+    .main-top .more-link a:hover,
+    .main-top .more-link a:focus,
+    .main-top a.more-link:hover,
+    .main-top a.more-link:focus {
+        color: $contrast_clr-page-bkg;
+        text-decoration: underline;
+    }
+}
+
+.stanford-jumpstart-home-serra.style-custom-styles-dark {
+    .main-top {
+        border-bottom: 1px solid $dark_clr-line;
+    }
+    .main-top,
+    .site-main-menu,
+    .header {
+        background: $dark_clr-header-bkg;
+    }
+}
+
+.stanford-jumpstart-home-serra.style-custom-styles-light {
+    .main-top {
+        border-bottom: 1px solid $light_clr-line;
+    }
+    .main-top,
+    .site-main-menu,
+    .header {
+        background: $light_clr-header-bkg;
+    }
+}
+
+.stanford-jumpstart-home-serra.style-custom-styles-plain {
+    .main-top {
+        border-bottom: 1px solid $plain_clr-line;
+    }
+    .main-top,
+    .site-main-menu,
+    .header {
+        background: $plain_clr-header-bkg;
+    }
+}
+
+.stanford-jumpstart-home-serra.style-custom-styles-rich {
+    .main-top {
+        border-bottom: 1px solid $rich_clr-line;
+    }
+    .main-top,
+    .site-main-menu,
+    .header {
+        background: $rich_clr-header-bkg;
+    }
+}
 
 
 /** LAYOUT: PANAMA ************************
-	- About block
-	- Banner image with overlay 
-	- Three blocks
+    - About block
+    - Banner image with overlay
+    - Three blocks
 ******************************************/
 
-.stanford-jumpstart-home-panama {
-	
-}
+.stanford-jumpstart-home-panama {}


### PR DESCRIPTION
Added support for site title theme options for the following jumpstart homepage layouts: Panama, Palm, Mayfield, Serra, and Lomita
