### PR TITLE
Initially disable contexts so they do not get enabled by default.

### DIFF
--- a/layouts/stanford_jumpstart_home_gibbons.inc
+++ b/layouts/stanford_jumpstart_home_gibbons.inc
@@ -6,7 +6,7 @@
  */
 
 $context = new stdClass();
-$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
 $context->api_version = 3;
 $context->name = 'stanford_jumpstart_home_gibbons';
 $context->description = 'Homepage: Gibbons layout with full-width banner, large about, news, four small custom block, and events.';

--- a/layouts/stanford_jumpstart_home_hoover.inc
+++ b/layouts/stanford_jumpstart_home_hoover.inc
@@ -5,7 +5,7 @@
  *  @author Caryl Westerberg <cjwest@stanford.edu>
  */
 $context = new stdClass();
-$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
 $context->api_version = 3;
 $context->name = 'stanford_jumpstart_home_hoover';
 $context->description = 'Homepage: Hoover layout with small and large custom blocks';

--- a/layouts/stanford_jumpstart_home_kays.inc
+++ b/layouts/stanford_jumpstart_home_kays.inc
@@ -6,7 +6,7 @@
  */
 
 $context = new stdClass();
-$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
 $context->api_version = 3;
 $context->name = 'stanford_jumpstart_home_kays';
 $context->description = 'Homepage: Kays layout with full-width banner, a large custom block, and a small custom block.';

--- a/layouts/stanford_jumpstart_home_morris.inc
+++ b/layouts/stanford_jumpstart_home_morris.inc
@@ -5,7 +5,7 @@
  *  @author Caryl Westerberg <cjwest@stanford.edu>
  */
 $context = new stdClass();
-$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
 $context->api_version = 3;
 $context->name = 'stanford_jumpstart_home_morris';
 $context->description = 'Homepage: Morris layout with news and events';

--- a/layouts/stanford_jumpstart_home_pettit.inc
+++ b/layouts/stanford_jumpstart_home_pettit.inc
@@ -5,7 +5,7 @@
  *  @author Caryl Westerberg <cjwest@stanford.edu>
  */
 $context = new stdClass();
-$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
 $context->api_version = 3;
 $context->name = 'stanford_jumpstart_home_pettit';
 $context->description = 'Homepage: Pettit layout with full-width banner, news, events, and a large custom block';

--- a/layouts/stanford_jumpstart_home_terman.inc
+++ b/layouts/stanford_jumpstart_home_terman.inc
@@ -5,7 +5,7 @@
  *  @author Caryl Westerberg <cjwest@stanford.edu>
  */
 $context = new stdClass();
-$context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+$context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
 $context->api_version = 3;
 $context->name = 'stanford_jumpstart_home_terman';
 $context->description = 'Homepage: Terman layout with full-width banner, news, events, large and small custom block\'';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Initially disables the contexts as older sites are getting the new contexts with them enabled.

# Needed By (Date)
- Soonish

# Urgency
- 2/5

# Steps to Test

1. Check out this branch
2. Install JSE and ensure correct contexts are enabled

---

1. Check out this branch on an older jse site (jse-icme)
2. Run drush updb
3. Visit the context page
4. See new contexts (gibbons) as disabled

# Affected Projects or Products
- JSE
- Cardinal D7
- ACSF Migrations

# Associated Issues and/or People
- https://github.com/SU-SWS/acsf-cardinald7/pull/171
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-1177
- Other PRs: (one forthcoming for ansible-playbooks
- Anyone who should be notified? ( @boznik @cjwest @minorwm @jbickar )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)